### PR TITLE
Add redis backed store

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -83,6 +83,35 @@ async function makeConfiggedWASocket(sessionId, state, store, saveCreds){
   return sock
 }
 
+// Creates a Baileys store that persists to Redis
+async function makeRedisStore(sessionId) {
+  const store = makeInMemoryStore({ logger });
+
+  const redisKey = `${sessionId}:store`;
+
+  try {
+    const dataStr = await redisClient.get(redisKey);
+    if (dataStr) {
+      store.fromJSON(JSON.parse(dataStr));
+    }
+  } catch (err) {
+    logger.error({ sessionId, err }, "Failed to load store from Redis");
+  }
+
+  const saveToRedis = async () => {
+    try {
+      await redisClient.set(redisKey, JSON.stringify(store.toJSON()));
+    } catch (err) {
+      logger.error({ sessionId, err }, "Failed to save store to Redis");
+    }
+  };
+
+  // Save store every 10 seconds
+  setInterval(saveToRedis, 10000);
+
+  return store;
+}
+
 /**
  * Creates a new WhatsApp session or returns an existing one
  * @param {string} id - Session identifier
@@ -96,7 +125,7 @@ async function createSession(id) {
   }
 
   const { state, saveCreds } = await useRedisAuthState(id);
-  const store = makeInMemoryStore({ logger });
+  const store = await makeRedisStore(id);
 
   const sock = await makeConfiggedWASocket(id, state, store, saveCreds)
 
@@ -179,6 +208,7 @@ export {
   getActiveSessions,
   deleteSession,
   sessions,
+  makeRedisStore,
   normalizeJid,
   restoreSessionsFromRedis
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,8 @@
 import {
   makeWASocket,
   makeInMemoryStore,
-  DisconnectReason
+  DisconnectReason,
+  BufferJSON
 } from "@whiskeysockets/baileys";
 import { useRedisAuthState, redisClient } from "./use_redis_auth_state.js"
 import logger from './logger.js'
@@ -92,7 +93,7 @@ async function makeRedisStore(sessionId) {
   try {
     const dataStr = await redisClient.get(redisKey);
     if (dataStr) {
-      store.fromJSON(JSON.parse(dataStr));
+      store.fromJSON(JSON.parse(dataStr, BufferJSON.reviver));
     }
   } catch (err) {
     logger.error({ sessionId, err }, "Failed to load store from Redis");
@@ -100,7 +101,7 @@ async function makeRedisStore(sessionId) {
 
   const saveToRedis = async () => {
     try {
-      await redisClient.set(redisKey, JSON.stringify(store.toJSON()));
+      await redisClient.set(redisKey, JSON.stringify(store.toJSON(), BufferJSON.replacer));
     } catch (err) {
       logger.error({ sessionId, err }, "Failed to save store to Redis");
     }

--- a/src/use_redis_auth_state.js
+++ b/src/use_redis_auth_state.js
@@ -32,7 +32,7 @@ async function useRedisAuthState(sessionId) {
             let valueStr = await redisClient.hGet(sessionId, redisKey);
             if (valueStr) {
               // Reconstruir objeto/Buffer desde JSON
-              let value = JSON.parse(valueStr);
+              let value = JSON.parse(valueStr, BufferJSON.reviver);
               if (type === 'app-state-sync-key' && value) {
                 // Reconstruir tipo proto Message.AppStateSyncKeyData
                 value = proto.Message.AppStateSyncKeyData.fromObject(value);


### PR DESCRIPTION
## Summary
- support persisting the Baileys store in Redis
- reuse stored data when recreating sessions

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684750bdfd408326a066f23e07e629d8